### PR TITLE
refactor: remove purgecss config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,6 @@ By setting this param to `true`, the creation of the `tailwind.config.js` and `t
 
 Change the path where the `tailwind.css` file should be created.
 
-### `defaultExtractor`
-
-- Type: `function`
-- Default
-```js
-content => {
-  const contentWithoutStyleBlocks = content.replace(/<style[^]+?<\/style>/gi, '');
-  return contentWithoutStyleBlocks.match(/[A-Za-z0-9-_/:!]*[A-Za-z0-9-_/]+/g) || [];
-}
-```
-
-Change the default extractor for `purgecss`. 
-
 ### `configPath`
 
 - Type: `string`

--- a/lib/__tests__/index.spec.js
+++ b/lib/__tests__/index.spec.js
@@ -91,16 +91,6 @@ describe('tailwind plugin', () => {
     expect(mockThis.config.webpack.postcss.preset).toEqual({ stage: 1 });
   });
 
-  test('should update purgecss in aver config', async() => {
-    await plugin.call(mockThis);
-    expect(mockThis.config.purgecss.defaultExtractor).toBeTruthy();
-
-    // should use the custom extractor when passed to the plugin
-    const defaultExtractor = jest.fn();
-    await plugin.call(mockThis, { defaultExtractor });
-    expect(mockThis.config.purgecss.defaultExtractor).toBe(defaultExtractor);
-  });
-
   test('should extract tailwind config, write it into json file and add alias', async() => {
     await mkdirp(cacheDir);
     const configPath = path.resolve(mockThis.config.cacheDir, './tailwind.config.json');

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,6 @@ export default async function(options = {}) {
   const {
     skipCreation = false,
     cssPath = './',
-    defaultExtractor,
     configPath = 'tailwind.config.js',
     resolveConfig = false
   } = options;
@@ -73,12 +72,4 @@ export default async function(options = {}) {
   if (!this.config.webpack.postcss.plugins) this.config.webpack.postcss.plugins = {};
   this.config.webpack.postcss.plugins.tailwindcss = configPath;
   this.config.webpack.postcss.preset = { stage: 1 };
-
-  const extractor = /* istanbul ignore next */ content => {
-    const contentWithoutStyleBlocks = content.replace(/<style[^]+?<\/style>/gi, '');
-    return contentWithoutStyleBlocks.match(/[A-Za-z0-9-_/:!]*[A-Za-z0-9-_/]+/g) || [];
-  };
-
-  if (!this.config.purgecss) this.config.purgecss = {};
-  this.config.purgecss.defaultExtractor = defaultExtractor || extractor;
 }

--- a/lib/templates/tailwind.config.js
+++ b/lib/templates/tailwind.config.js
@@ -1,5 +1,9 @@
 module.exports = {
   theme: {},
   variants: {},
-  plugins: []
+  plugins: [],
+  purge: [
+    './src/**/*.js',
+    './src/**/*.vue'
+  ]
 };


### PR DESCRIPTION
BREAKING CHANGE: since tailwind version 1.4.0 there is purge integrated and the purgecss aver plugin is not needed anymore.